### PR TITLE
修复了首页跳转到快速开始页时404的问题

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -9,4 +9,4 @@
 - 丰富的附加功能
 
 [GitHub](https://github.com/jin-yufeng/mp-html)
-[快速开始](quickstart)
+[快速开始](/overview/quickstart)


### PR DESCRIPTION
首页跳转快速开始页点击会404，经过排查发现是链接的问题，已经修改。