### PR TITLE
fix #276 开启代码高亮后,无语言代码块样式bug

### DIFF
--- a/plugins/highlight/index.js
+++ b/plugins/highlight/index.js
@@ -24,55 +24,57 @@ highlight.prototype.onParse = function (node, vm) {
       className = node.attrs.class || ''
       i = className.indexOf('language-')
     }
-    if (i != -1) {
-      i += 9
-      for (var j = i; j < className.length; j++)
-        if (className[j] == ' ')
-          break
-      var lang = className.substring(i, j)
-      if (code.children.length && code.children[0].type == 'text') {
-        if (prism.languages[lang]) {
-          var text = code.children[0].text.replace(/&amp;/g, '&')
-          code.children = (new parser(this.vm).parse(
-            // 加一层 pre 保留空白符
-            '<pre>' + prism.highlight(text, prism.languages[lang], lang).replace(/token /g, 'hl-') + '</pre>'))[0].children
-        }
-        node.attrs.class = 'hl-pre'
-        code.attrs.class = 'hl-code'
-        if (config.showLanguageName)
-          node.children.push({
-            name: 'div',
-            attrs: {
-              class: 'hl-language',
-              style: 'user-select:none'
-            },
-            children: [{
-              type: 'text',
-              text: lang
-            }]
-          })
-        if (config.copyByLongPress) {
-          node.attrs.style += (node.attrs.style || '') + ';user-select:none'
-          node.attrs['data-content'] = text
-          vm.expose()
-        }
-        if (config.showLineNumber) {
-          var line = text.split('\n').length, children = []
-          for (var k = line; k--;)
-            children.push({
-              name: 'span',
-              attrs: {
-                class: 'span'
-              }
-            })
-          node.children.push({
+    if (i == -1) {
+      className = 'language-text'
+      i = className.indexOf('language-')
+    }
+    i += 9
+    for (var j = i; j < className.length; j++)
+      if (className[j] == ' ')
+        break
+    var lang = className.substring(i, j)
+    if (code.children.length && code.children[0].type == 'text') {
+      var text = code.children[0].text.replace(/&amp;/g, '&')
+      if (prism.languages[lang]) {
+        code.children = (new parser(this.vm).parse(
+          // 加一层 pre 保留空白符
+          '<pre>' + prism.highlight(text, prism.languages[lang], lang).replace(/token /g, 'hl-') + '</pre>'))[0].children
+      }
+      node.attrs.class = 'hl-pre'
+      code.attrs.class = 'hl-code'
+      if (config.showLanguageName)
+        node.children.push({
+          name: 'div',
+          attrs: {
+            class: 'hl-language',
+            style: 'user-select:none'
+          },
+          children: [{
+            type: 'text',
+            text: lang
+          }]
+        })
+      if (config.copyByLongPress) {
+        node.attrs.style += (node.attrs.style || '') + ';user-select:none'
+        node.attrs['data-content'] = text
+        vm.expose()
+      }
+      if (config.showLineNumber) {
+        var line = text.split('\n').length, children = []
+        for (var k = line; k--;)
+          children.push({
             name: 'span',
             attrs: {
-              class: 'line-numbers-rows'
-            },
-            children
+              class: 'span'
+            }
           })
-        }
+        node.children.push({
+          name: 'span',
+          attrs: {
+            class: 'line-numbers-rows'
+          },
+          children
+        })
       }
     }
   }


### PR DESCRIPTION
## 提交原因
#276 开启代码高亮后，无语言导致样式消失或指定语言不存在于高亮范畴导致复制功能无法使用

## 主要修改
* 增加默认语言
```JavaScript
if (i == -1) {
  className = 'language-text'
  i = className.indexOf('language-')
}
```
* 因增加默认语言，即去掉`i != -1`判断
* text(代码内容)赋值位置改变，避免找不到指定语言导致复制功能无法使用
将`var text = code.children[0].text.replace(/&amp;/g, '&')`移动到`if (prism.languages[lang]) {`外层

## 测试
已测试微信小程序