### PR TITLE
feat: 🎸 使用uni-app开发微信小程序时，当从vue2迁移到vue3后，此组件需要改如下几个地方。否则无法正常渲染。

### DIFF
--- a/src/uni-app/components/mp-html/mp-html.vue
+++ b/src/uni-app/components/mp-html/mp-html.vue
@@ -40,7 +40,7 @@
 import node from './node/node'
 // #endif
 const plugins = []
-const Parser = require('./parser')
+import Parser from './parser'
 // #ifdef APP-PLUS-NVUE
 const dom = weex.requireModule('dom')
 // #endif

--- a/src/uni-app/components/mp-html/node/node.vue
+++ b/src/uni-app/components/mp-html/node/node.vue
@@ -54,7 +54,7 @@
       <!-- insert -->
       <!-- 富文本 -->
       <!-- #ifdef H5 || MP-WEIXIN || MP-QQ || APP-PLUS || MP-360 -->
-      <rich-text v-else-if="handler.use(n)" :id="n.attrs.id" :style="n.f" :nodes="[n]" />
+      <rich-text v-else-if="handlerUse(n)" :id="n.attrs.id" :style="n.f" :nodes="[n]" />
       <!-- #endif -->
       <!-- #ifndef H5 || MP-WEIXIN || MP-QQ || APP-PLUS || MP-360 -->
       <rich-text v-else-if="!n.c" :id="n.attrs.id" :style="n.f+';display:inline'" :preview="false" :nodes="[n]" />
@@ -67,7 +67,8 @@
     </block>
   </view>
 </template>
-<script module="handler" lang="wxs">
+<script>
+import node from './node'
 // 行内标签列表
 var inlineTags = {
   abbr: true,
@@ -86,19 +87,6 @@ var inlineTags = {
   sub: true,
   sup: true
 }
-/**
- * @description 是否使用 rich-text 显示剩余内容
- */
-module.exports = {
-  use: function (item) {
-    if (item.c) return false
-    // 微信和 QQ 的 rich-text inline 布局无效
-    return !inlineTags[item.name] && (item.attrs.style || '').indexOf('display:inline') == -1
-  }
-}
-</script>
-<script>
-import node from './node'
 export default {
   name: 'node',
   options: {
@@ -161,6 +149,14 @@ export default {
     // #endif
   },
   methods: {
+    /**
+     * @description 是否使用 rich-text 显示剩余内容
+     */
+    handlerUse (item) {
+      if (item.c) return false
+      // 微信和 QQ 的 rich-text inline 布局无效
+      return !inlineTags[item.name] && (item.attrs.style || '').indexOf('display:inline') == -1
+    },
     // #ifdef MP-WEIXIN
     toJSON () { },
     // #endif

--- a/src/uni-app/components/mp-html/parser.js
+++ b/src/uni-app/components/mp-html/parser.js
@@ -1238,4 +1238,4 @@ Lexer.prototype.endTag = function () {
   }
 }
 
-module.exports = Parser
+export default Parser


### PR DESCRIPTION
### 问题场景
* uni-app vue2升级到vue3
### 开发工具
* HBuilder X 3.3.10.20220124
### 改动逻辑
  * [x] 1、导入需要使用`import`，否则无法解析。 
  * [x] 2、导出需要使用`export`，否则无法解析。 
  * [x] 3、`wxs`语法解析不了，导致报错：`ReferenceError: handler is not defined`。
    - [x] 所以我把`wxs`语法中的逻辑，挪到了`js`中。
    - [x] 然后把`handler.use(n)`改为了`handlerUse(n)`。
### 新年祝福
  * 祝看到此条PR的各位，新年快乐，身体健康，万事如意。