### PR TITLE
fix: glass-easel 框架下真机换行异常

### DIFF
--- a/src/miniprogram/node/node.wxml
+++ b/src/miniprogram/node/node.wxml
@@ -43,7 +43,7 @@
   <!-- #ifdef MP-WEIXIN || MP-QQ || MP-TOUTIAO -->
   <text wx:elif="{{n.text}}" mp-weixin:user-select="{{opts[4]=='force'&&isiOS}}" decode>{{n.text}}</text>
   <!-- #endif -->
-  <text wx:elif="{{n.name==='br'}}">\n</text>
+  <text wx:elif="{{n.name==='br'}}">{{'\n'}}</text>
   <!-- 链接 -->
   <view wx:elif="{{n.name==='a'}}" id="{{n.attrs.id}}" class="{{n.attrs.href?'_a ':''}}{{n.attrs.class}}" hover-class="_hover" style="display:inline;{{n.attrs.style}}" data-i="{{i}}" catchtap="linkTap">
     <!-- #ifdef MP-WEIXIN || MP-QQ -->


### PR DESCRIPTION
对于问题：[小程序真机预览换行符\n失效，但模拟器是正常的，请问是什么情况？ | 微信开放社区](https://developers.weixin.qq.com/community/develop/doc/000c6440938a38217b71d63686b400)，官方回复：

> 当开发者配置了 "componentFramework": "glass-easel" 就会有这个问题，是符合预期的。参考这里的变更点适配 1 https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/glass-easel/migration.html#JSON-%E9%85%8D%E7%BD%AE
>
> 试试用绑定把换行写进数据绑定里

实测将 `\n` 换为 `{{'\n'}}` 可以解决 WebView glass-easel 下真机（基础库 3.5.3，WebView 配置 glass-easel）的换行问题。其他模式未测。