### PR TITLE
chore(latex): 更新KaTeX字体链接至0.15.2版本, 修复部分公式符号渲染错误的问题

### DIFF
--- a/plugins/latex/katex.css
+++ b/plugins/latex/katex.css
@@ -1,121 +1,121 @@
 /* fonts字体库可自行前往 https://github.com/KaTeX/KaTeX/tree/main/fonts 下载，放入自家的cdn服务上 */
 @font-face {
   font-family: "KaTeX_AMS";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_AMS-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_AMS-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_AMS-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_AMS-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_AMS-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_AMS-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Caligraphic";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Bold.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Caligraphic";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Caligraphic-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Caligraphic-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Fraktur";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Bold.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Fraktur";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Fraktur-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Fraktur-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Main";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Bold.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Main";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-BoldItalic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-BoldItalic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-BoldItalic.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-BoldItalic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-BoldItalic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-BoldItalic.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
 @font-face {
   font-family: "KaTeX_Main";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Italic.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Italic.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 @font-face {
   font-family: "KaTeX_Main";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Main-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Main-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Math";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-BoldItalic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-BoldItalic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-BoldItalic.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-BoldItalic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-BoldItalic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-BoldItalic.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
 @font-face {
   font-family: "KaTeX_Math";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Math-Italic.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Math-Italic.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 @font-face {
   font-family: "KaTeX_SansSerif";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Bold.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Bold.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Bold.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_SansSerif";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Italic.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Italic.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Italic.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Italic.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 @font-face {
   font-family: "KaTeX_SansSerif";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_SansSerif-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_SansSerif-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Script";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Script-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Script-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Script-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Script-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Script-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Script-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Size1";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size1-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size1-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size1-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size1-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size1-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size1-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Size2";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size2-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size2-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size2-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size2-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size2-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size2-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Size3";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size3-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size3-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size3-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size3-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size3-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size3-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Size4";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size4-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size4-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Size4-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size4-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size4-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Size4-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "KaTeX_Typewriter";
-  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Typewriter-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Typewriter-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.13.16/fonts/KaTeX_Typewriter-Regular.ttf") format("truetype");
+  src: url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Typewriter-Regular.woff2") format("woff2"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Typewriter-Regular.woff") format("woff"), url("https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.15.2/fonts/KaTeX_Typewriter-Regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
问题:
![bug_image](https://github.com/user-attachments/assets/19252fce-6020-4cf6-8b05-6555264b5f83)
在0.13.16版本字体的情况下 公式内的 `∈` 符号的渲染高度会出现问题
将字体版本更改为较高版本后问题得以解决

修复后:
![ffc65dc0b31a81899a5a6f61149bca6](https://github.com/user-attachments/assets/3e3897de-6592-4afc-8e02-36d9743396c1)
