### PR TITLE
fix: latex支持"\["公式支持 - #606bug

### DIFF
--- a/plugins/latex/index.js
+++ b/plugins/latex/index.js
@@ -10,8 +10,13 @@ function Latex () {
 
 Latex.prototype.onParse = function (node, vm) {
   // $...$包裹的内容为latex公式
-  if (!vm.options.editable && node.type === 'text' && node.text.includes('$')) {
-    const part = node.text.split(/(\${1,2})/)
+  if (!vm.options.editable && node.type === 'text' && (node.text.includes('$') || node.text.includes('\[') && node.text.includes('\\'))) {
+    let part
+    if (node.text.includes('\[')) {
+      part = node.text.split(/(\[|\])/)
+    } else {
+      part = node.text.split(/(\${1,2})/)
+    }
     const children = []
     let status = 0
     for (let i = 0; i < part.length; i++) {
@@ -26,7 +31,11 @@ Latex.prototype.onParse = function (node, vm) {
           } else {
             if (status === 1) {
               // 行内公式
-              const nodes = parse.default(part[i])
+              // 处理百分号和负间距
+              let formula = part[i].replace(/(?<!\\)%/g, '\\%')
+              // 匹配 LaTeX 中的 \! 和 \, 命令
+              formula = formula.replace(/\!|\\,/g, '')
+              const nodes = parse.default(formula)
               children.push({
                 name: 'span',
                 attrs: {},
@@ -36,7 +45,11 @@ Latex.prototype.onParse = function (node, vm) {
               })
             } else {
               // 块公式
-              const nodes = parse.default(part[i], {
+              // 处理百分号和负间距
+              let formula = part[i].replace(/(?<!\\)%/g, '\\%')
+              // 匹配 LaTeX 中的 \! 和 \, 命令
+              formula = formula.replace(/\!|\\,/g, '')
+              const nodes = parse.default(formula, {
                 displayMode: true
               })
               children.push({
@@ -55,7 +68,7 @@ Latex.prototype.onParse = function (node, vm) {
           // 行内公式
           status = 1
           part[i + 2] = ''
-        } else if (part[i] === '$$' && part[i + 2] === '$$') {
+        } else if ((part[i] === '$$' && part[i + 2] === '$$') || (part[i].includes('[') && part[i + 2].includes(']'))) {
           // 块公式
           status = 2
           part[i + 2] = ''


### PR DESCRIPTION
fix:修复latex公式不支持展示"\[".
deepseek-AI回答都是"\["格式显示公式,公司对接的是deepseek-AI,发现公式显示错误,已修复,顺带修复公式中%分号显示错误

数据参考:
"根据中国个人所得税法，您作为老师在外讲课所得属于**劳务报酬**，需按以下步骤计算税前金额：\n\n---\n\n### **1. 应纳税所得额计算**\n劳务报酬每次收入超过4000元时，先扣除**20%**的费用，剩余部分为应纳税所得额：\n\\[\n\\text{应纳税所得额} = \\text{税前金额} \\times (1 - 20\\%) = 0.8X\n\\]\n\n---\n\n### **2. 预扣税率**\n根据应纳税所得额，适用**三级超额累进税率**：\n- **≤20,000元**：20%（速算扣除数0）\n- **20,000~50,000元**：30%（速算扣除数2000）\n- **>50,000元**：40%（速算扣除数7000）\n\n---\n\n### **3. 方程推导**\n已知税后收入为44,560元，设税前金额为\\( X \\)，则：\n\\[\nX - \\text{预扣税款} = 44,560\n\\]\n其中，预扣税款公式为：\n\\[\n\\text{预扣税款} = 0.8X \\times \\text{税率} - \\text{速算扣除数}\n\\]\n\n通过试算确定适用税率档次：\n- 若\\( 0.8X > 20,000 \\)且\\( 0.8X \\leq 50,000 \\)，适用**30%税率**：\n\\[\n\\text{预扣税款} = 0.8X \\times 30\\% - 2000\n\\]\n代入方程：\n\\[\nX - (0.24X - 2000) = 44,560 \\quad \\Rightarrow \\quad 0.76X = 42,560 \\quad \\Rightarrow \\quad X = \\frac{42,560}{0.76} = 56,000\n\\]\n\n---\n\n### **4. 验证**\n- **应纳税所得额**：\\( 56,000 \\times 0.8 = 44,800 \\)元（适用30%税率）\n- **预扣税款**：\\( 44,800 \\times 30\\% - 2000 = 11,440 \\)元\n- **税后收入**：\\( 56,000 - 11,440 = 44,560 \\)元（与已知一致）\n\n---\n\n### **结论**\n对方**税前应支付**的金额为：\n\\[\n\\boxed{56,\\!000\\ \\text{元}}\n\\] 这些数学公式用$$来声明\n\n"