### PR TITLE
fix: 修复微信小程序ios流式聊天，有序列表偶现折行bug - #649

### DIFF
--- a/src/uni-app/components/mp-html/node/node.vue
+++ b/src/uni-app/components/mp-html/node/node.vue
@@ -73,7 +73,7 @@
       <rich-text v-else-if="!n.c&&!handler.isInline(n.name, n.attrs.style)" :id="n.attrs.id" :style="n.f" :user-select="opts[4]" :nodes="[n]" />
       <!-- #endif -->
       <!-- #ifndef H5 || ((MP-WEIXIN || MP-QQ || APP-PLUS || MP-360) && VUE2) -->
-      <rich-text v-else-if="!n.c" :id="n.attrs.id" :style="'display:inline;'+n.f" :preview="false" :selectable="opts[4]" :user-select="opts[4]" :nodes="[n]" />
+      <rich-text v-else-if="!n.c && n.name !=='p' && n.name !=='strong'" :id="n.attrs.id" :style="'display:inline;'+n.f" :preview="false" :selectable="opts[4]" :user-select="opts[4]" :nodes="[n]" />
       <!-- #endif -->
       <!-- 继续递归 -->
       <view v-else-if="n.c===2" :id="n.attrs.id" :class="'_block _'+n.name+' '+n.attrs.class" :style="n.f+';'+n.attrs.style">


### PR DESCRIPTION
<img width="455" height="270" alt="image" src="https://github.com/user-attachments/assets/972108ae-70c6-4e0d-a8c2-84258c4973d4" />
<img width="264" height="110" alt="image" src="https://github.com/user-attachments/assets/2e56c305-b863-4a17-a242-9176ff7a7a3c" />

在微信小程序环境因rich-text是块元素,所以会展示换行,现在对node.vue代码进行修改后,修复此bug