### PR TITLE
fix: 修复加粗文本遇到中文符号异常显示bug - #663

### DIFF
--- a/plugins/markdown/index.js
+++ b/plugins/markdown/index.js
@@ -13,6 +13,8 @@ function Markdown (vm) {
 
 Markdown.prototype.onUpdate = function (content) {
   if (this.vm.properties.markdown) {
+    // 解决中文标点符号后粗体失效的问题，增加零宽空格
+    content = content.replace(/\*\*([^*]+)\*\*([，。！？；：])/g, '**$1**&#8203;$2');
     return marked(content)
   }
 }


### PR DESCRIPTION
markdown/index.js 导入了 marked.min.js ，并使用它来转换 Markdown。marked.js 以及其他一些 Markdown 解析库在处理中文标点符号时确实存在一些已知问题。 1 4 问题的根源在于这些库的解析规则通常是为英文等使用空格分隔单词的语言设计的，而中文等东亚语言的标点用法与此不同。

采取预处理的方式，在 ** 和中文标点之间插入一个零宽空格（ &#8203; ），解决这类渲染问题。修改 mp-html/markdown/index.js 文件，在调用 marked() 之前，对传入的 content 进行处理。
修复以后已正常显示
<img width="993" height="176" alt="image" src="https://github.com/user-attachments/assets/91578b19-b55b-42b5-88cc-d41fed9c19f4" />
